### PR TITLE
Get more fit info

### DIFF
--- a/XIDp_mod_beta.py
+++ b/XIDp_mod_beta.py
@@ -256,7 +256,7 @@ def lstdrv_SPIRE_stan(SPIRE_250,SPIRE_350,SPIRE_500,chains=4,iter=1000):
             pickle.dump(sm, f)
         fit = sm.sampling(data=XID_data,iter=iter,chains=chains)
     #extract fit
-    fit_data=fit.extract(permuted=False, inc_warmup=False)
+    #fit_data=fit.extract(permuted=False, inc_warmup=False)
     #return fit data
     
     return fit
@@ -407,9 +407,9 @@ def lstdrv_SPIRE_prior_stan(SPIRE_250,SPIRE_350,SPIRE_500,chains=4,iter=1000):
             pickle.dump(sm, f)
         fit = sm.sampling(data=XID_data,iter=iter,chains=chains)
     #extract fit
-    fit_data=fit.extract(permuted=False, inc_warmup=False)
+    #fit_data=fit.extract(permuted=False, inc_warmup=False)
     #return fit data
-    return fit_data,chains,iter
+    return fit
 
 class posterior_stan(object):
     def __init__(self,fit,nsrc):
@@ -431,7 +431,7 @@ class posterior_stan(object):
             print self.Rhat[ind_Rhat], np.array(fit.constrained_param_names())[ind_Rhat]
         if ind_n_eff.sum() > 0:
             print 'Not all parameters have enough effective samples'
-            print ind_n_eff[ind_n_eff],np.array(fit.constrained_param_names())[ind_n_eff]
+            print self.n_eff[ind_n_eff],np.array(fit.constrained_param_names())[ind_n_eff]
     
     # define a function to get percentile for a particular parameter
     def quantileGet(self,q):

--- a/scripts/XIDplus_vs_DESPHOT_Laceysim-100micron.py
+++ b/scripts/XIDplus_vs_DESPHOT_Laceysim-100micron.py
@@ -59,7 +59,7 @@ hdulist.close()
 
 #---Read in XID+Tiling catalogue---
 folder='/research/astro/fir/HELP/XID_plus_output/100micron/log_prior_flux/'
-hdulist=fits.open(folder+'Tiled_SPIRE_cat_flux_notlog.fits')
+hdulist=fits.open(folder+'Tiled_SPIRE_cat_flux_notlog_old.fits')
 fcat_xidpT=hdulist[1].data
 hdulist.close()
 

--- a/scripts/combine_tiles_posterior.py
+++ b/scripts/combine_tiles_posterior.py
@@ -6,9 +6,12 @@ from astropy.io import fits
 from astropy import wcs
 import pickle
 import dill
+import sys
+
+sys.path.append('/research/astro/fir/HELP/XID_plus/')
+
 import XIDp_mod_beta as xid_mod
 import os
-import sys
 
 #----output folder-----------------
 output_folder='/research/astro/fir/HELP/XID_plus_output/100micron/log_prior_flux/'
@@ -28,7 +31,7 @@ for i in np.arange(0,len(tiles)):
     #find which sources from master list are we interested in
     ind= (np.around(tiling_list[:,2],3) == np.around(tile[0,0],3)) & (np.around(tiling_list[:,3],3) == np.around(tile[1,0],3))
     if ind.sum() >0:
-	    infile=output_folder+'Lacey_log10_norm0_5_'+str(tile[0,0]).replace('.','_')+'p'+str(tile[1,0]).replace('.','_')+'.pkl'
+	    infile=output_folder+'Lacey_log10_norm1_'+str(tile[0,0]).replace('.','_')+'p'+str(tile[1,0]).replace('.','_')+'.pkl'
 	    with open(infile, "rb") as f:
 		dictname = pickle.load(f)
 	    prior250=dictname['psw']
@@ -84,16 +87,19 @@ plwfits=imfolder+'cosmos_itermap_lacey_07012015_simulated_observation_w_noise_PL
 #-----250-------------
 hdulist = fits.open(pswfits)
 w_250 = wcs.WCS(hdulist[1].header)
+imhdu250=hdulist[1].header
 pixsize250=3600.0*w_250.wcs.cd[1,1] #pixel size (in arcseconds)
 hdulist.close()
 #-----350-------------
 hdulist = fits.open(pmwfits)
 w_350 = wcs.WCS(hdulist[1].header)
+imhdu350=hdulist[1].header
 pixsize350=3600.0*w_350.wcs.cd[1,1] #pixel size (in arcseconds)
 hdulist.close()
 #-----500-------------
 hdulist = fits.open(plwfits)
 w_500 = wcs.WCS(hdulist[1].header)
+imhdu500=hdulist[1].header
 pixsize500=3600.0*w_500.wcs.cd[1,1] #pixel size (in arcseconds)
 hdulist.close()
 
@@ -104,17 +110,17 @@ hdulist.close()
 
 prior_cat_file='lacey_07012015_MillGas.ALLVOLS_cat_PSW_COSMOS_test.fits'
 #---------create master classes------------------------
-prior250_master=xid_mod.prior(prior250.im,prior250.nim,w_250,prior250.imphdu)#Initialise with map, uncertianty map, wcs info and primary header
+prior250_master=xid_mod.prior(prior250.im,prior250.nim,prior250.imphdu,imhdu250)#Initialise with map, uncertianty map, wcs info and primary header
 #print help(prior250_master.prior_cat)
 prior250_master.prior_cat(tiling_list[:,0],tiling_list[:,1],prior_cat_file)
-prior350_master=xid_mod.prior(prior350.im,prior350.nim,w_350,prior350.imphdu)#Initialise with map, uncertianty map, wcs info and primary header
+prior350_master=xid_mod.prior(prior350.im,prior350.nim,prior350.imphdu,imhdu350)#Initialise with map, uncertianty map, wcs info and primary header
 prior350_master.prior_cat(tiling_list[:,0],tiling_list[:,1],prior_cat_file)
-prior500_master=xid_mod.prior(prior500.im,prior500.nim,w_500,prior500.imphdu)#Initialise with map, uncertianty map, wcs info and primary header
+prior500_master=xid_mod.prior(prior500.im,prior500.nim,prior500.imphdu,imhdu500)#Initialise with map, uncertianty map, wcs info and primary header
 prior500_master.prior_cat(tiling_list[:,0],tiling_list[:,1],prior_cat_file)
 
 posterior_master=xid_mod.posterior_stan(stan_fit_master,nsources)
 
-with open(output_folder+'Tiled_master_Lacey_notlog_flux_norm0_5.pkl', 'wb') as f:
+with open(output_folder+'Tiled_master_Lacey_notlog_flux_norm1.pkl', 'wb') as f:
     pickle.dump({'psw':prior250_master,'pmw':prior350_master,'plw':prior500_master,'posterior':posterior_master},f)
 
 

--- a/scripts/make_master_catalogue.py
+++ b/scripts/make_master_catalogue.py
@@ -15,7 +15,7 @@ import os
 
 folder='/research/astro/fir/HELP/XID_plus_output/100micron/log_prior_flux/'
 
-infile=folder+'Tiled_master_Lacey_notlog_flux_norm0_5.pkl'
+infile=folder+'Tiled_master_Lacey_notlog_flux_norm1.pkl'
 with open(infile, "rb") as f:
     obj = pickle.load(f)
 prior250=obj['psw']
@@ -25,5 +25,5 @@ prior500=obj['plw']
 posterior=obj['posterior']
 
 thdulist_master=xid_mod.create_XIDp_SPIREcat_nocov(posterior,prior250,prior350,prior500)
-thdulist_master.writeto(folder+'Tiled_SPIRE_cat_flux_notlog_norm0_5.fits')
+thdulist_master.writeto(folder+'Tiled_SPIRE_cat_flux_notlog_norm1.fits')
 

--- a/scripts/metrics_plots.py
+++ b/scripts/metrics_plots.py
@@ -1,0 +1,117 @@
+#---import modules---
+from astropy.io import fits
+import numpy as np
+import matplotlib
+matplotlib.use('PDF')
+import pylab as plt
+from matplotlib.backends.backend_pdf import PdfPages
+import sys
+sys.path.append('/research/astro/fir/HELP/XID_plus/')
+import XIDp_mod_beta
+import pickle
+pdf_pages=PdfPages("error_density_flux_test_uninform.pdf")
+
+#---Read in DESPHOT catalogue---
+#folder='/research/astro/fir/HELP/DESPHOT/'
+#hdulist=fits.open(folder+'cosmos_itermap_lacey_07012015_simulated_observation_w_noise__PSWXID_S100_50mic_test.fits')
+#fcat=hdulist[1].data
+#ind=fcat['xid'] >= 0
+#fcat=fcat[ind]
+#hdulist.close()
+
+#---Read in truth catalogue---
+folder='/research/astro/fir/cclarke/lacey/released/'
+hdulist=fits.open(folder+'lacey_07012015_MillGas.ALLVOLS_cat_PSW_COSMOS_test.fits')
+fcat_sim=hdulist[1].data
+hdulist.close()
+
+fcat_sim=fcat_sim[fcat_sim['S100']>0.050]
+
+#---match DESPHOT and real catalogues---
+#from astropy.coordinates import SkyCoord
+#from astropy import units as u
+#c= SkyCoord(ra=fcat['INRA']*u.degree,dec=fcat['INDEC']*u.degree)
+#c1=SkyCoord(ra=fcat_sim['RA']*u.degree,dec=fcat_sim['DEC']*u.degree)
+#idx,d2d,d3d,= c.match_to_catalog_sky(c1)
+
+idx_xidp=fcat_sim['S100'] >0.050#cut so that only sources with a 100micron flux of > 50 micro janskys (Roseboom et al. 2010 cut 24 micron sources at 50microJys)
+idx_xidpT=fcat_sim['S100'] >0.050#cut so that only sources with a 100micron flux of > 50 micro janskys (Roseboom et al. 2010 cut 24 micron sources at 50microJys)
+
+
+#---Read in XID+ posterior---
+
+#folder='/research/astro/fir/HELP/XID_plus_output/100micron/log_prior_flux/'
+folder='/research/astro/fir/HELP/XID_plus_output/100micron/log_uniform_prior_test/'
+infile=folder+'Tiled_master_Lacey_notlog_flux.pkl'
+with open(infile, "rb") as f:
+    obj = pickle.load(f)
+prior250=obj['psw']
+prior350=obj['pmw']    
+prior500=obj['plw']
+
+posterior=obj['posterior']
+
+samples,chains,params=posterior.stan_fit.shape
+flattened_post=posterior.stan_fit.reshape(samples*chains,params)
+nsources_xidp=idx_xidp.size
+#nsources_xid=idx.size
+
+
+
+error_percent_xidp_250=np.empty((nsources_xidp))
+IQR_xidp_250=np.empty((nsources_xidp))
+accuracy_xidp_250=np.empty((nsources_xidp))
+#error_percent_xid_250=np.empty((nsources_xid))
+
+import scipy.stats as stats
+for i in range(0,nsources_xidp):
+    error_percent_xidp_250[i]=stats.percentileofscore(flattened_post[:,i],fcat_sim['S250'][idx_xidp][i])
+    IQR_xidp_250[i]=np.subtract(*np.percentile(flattened_post[:,i],[75.0,25.0]))/np.median(flattened_post[:,i])
+    accuracy_xidp_250[i]=(np.median(flattened_post[:,i])-fcat_sim['S250'][idx_xidp][i])/fcat_sim['S250'][idx_xidp][i]
+
+#for i in range(0,nsources_xid):
+#    error_percent_xid_250[i]=100.0*stats.norm.cdf(fcat_sim['S250'][idx][i],loc=fcat['F250'][i],scale=fcat['E250'][i])
+ind_3mjy=fcat_sim['S250'][idx_xidp]>3
+
+bins=np.array([0.0,0.0032,0.135,2.275,15.87,50.0,84.13,97.725,99.865,99.9968,100.0])
+hist_xidp,bin_eges_xidp=np.histogram(error_percent_xidp_250[ind_3mjy],bins)
+#hist_xid,bin_eges_xid=np.histogram(error_percent_xid_250,bins)
+sigma=np.arange(-4.5,5.0,1)
+fig=plt.figure()
+#plt.plot(sigma,hist_xid/float(nsources_xid), label='DESPHOT')
+plt.plot(sigma,hist_xidp/float(ind_3mjy.sum()), 'r',label='XID+')
+plt.xlabel('Flux error density (Sigma)')
+
+plt.legend()
+pdf_pages.savefig(fig)
+
+fig2=plt.figure()
+#H,xedge,yedge=np.histogram2d(np.log10(fcat_sim['S250'][idx_xidp]),error_percent_xidp_250,bins=[np.arange(-3,3,0.25),bins])
+H,xedges,yedges=np.histogram2d(np.log10(fcat_sim['S250'][idx_xidp]),error_percent_xidp_250,bins=[np.arange(0.5,2.2,0.01),bins])
+plt.imshow(H.T/np.sum(H.T,axis=0),interpolation='nearest',extent=[xedges[0],xedges[-1],sigma[0],sigma[-1]],origin='low',aspect='auto')
+plt.xlabel('S250 mJy')
+plt.ylabel('z score')
+print H.shape,xedges.shape,yedges.shape
+plt.colorbar()
+pdf_pages.savefig(fig2)
+#bins=[np.arange(-3,3,0.25),bin_eges_xidp]
+
+
+#flux precision
+fig3=plt.figure()
+H,xedges,yedges=np.histogram2d(np.log10(fcat_sim['S250'][idx_xidp]),IQR_xidp_250,bins=[np.arange(0.5,2.2,0.01),np.arange(0,2,0.05)])
+plt.imshow(H.T/np.sum(H.T,axis=0),interpolation='nearest',extent=[xedges[0],xedges[-1],yedges[0],yedges[-1]],origin='low',aspect='auto')
+plt.xlabel('S250 mJy')
+plt.ylabel('IQR mJy/True')
+plt.colorbar()
+pdf_pages.savefig(fig3)
+
+fig4=plt.figure()
+H,xedges,yedges=np.histogram2d(np.log10(fcat_sim['S250'][idx_xidp]),accuracy_xidp_250,bins=[np.arange(0.5,2.2,0.01),np.arange(-2,2,0.01)])
+plt.imshow(H.T/np.sum(H.T,axis=0),interpolation='nearest',extent=[xedges[0],xedges[-1],yedges[0],yedges[-1]],origin='low',aspect='auto')
+plt.xlabel('S250 mJy')
+plt.ylabel('Obs -True / True mJy')
+plt.colorbar()
+pdf_pages.savefig(fig4)
+
+pdf_pages.close()

--- a/scripts/metrics_plots_DESPHOT.py
+++ b/scripts/metrics_plots_DESPHOT.py
@@ -1,0 +1,106 @@
+#---import modules---
+from astropy.io import fits
+import numpy as np
+import matplotlib
+matplotlib.use('PDF')
+import pylab as plt
+from matplotlib.backends.backend_pdf import PdfPages
+import sys
+sys.path.append('/research/astro/fir/HELP/XID_plus/')
+import XIDp_mod_beta
+import pickle
+pdf_pages=PdfPages("error_density_flux_test_DESPHOT.pdf")
+
+#---Read in DESPHOT catalogue---
+folder='/research/astro/fir/HELP/DESPHOT/'
+hdulist=fits.open(folder+'cosmos_itermap_lacey_07012015_simulated_observation_w_noise__PSWXID_S100_50mic_test.fits')
+fcat=hdulist[1].data
+nsources_xid=fcat.shape[0]
+print nsources_xid
+hdulist.close()
+
+#---Read in truth catalogue---
+hdulist=fits.open(folder+'lacey_07012015_MillGas.ALLVOLS_cat_PSW_COSMOS_test_pacs100_50cut.fits')
+fcat_sim=hdulist[1].data
+hdulist.close()
+
+
+
+
+
+
+#error_percent_xidp_250=np.empty((nsources_xidp))
+#IQR_xidp_250=np.empty((nsources_xidp))
+#accuracy_xidp_250=np.empty((nsources_xidp))
+error_percent_xid1_250=np.empty((nsources_xid))
+error_percent_xid2_250=np.empty((nsources_xid))
+accuracy_xid_250=np.empty((nsources_xid))
+IQR_xid_250=np.empty((nsources_xid))
+
+import scipy.stats as stats
+#for i in range(0,nsources_xidp):
+#    error_percent_xidp_250[i]=stats.percentileofscore(flattened_post[:,i],fcat_sim['S250'][idx_xidp][i])
+#    IQR_xidp_250[i]=np.subtract(*np.percentile(flattened_post[:,i],[75.0,25.0]))/np.median(flattened_post[:,i])
+#    accuracy_xidp_250[i]=(np.median(flattened_post[:,i])-fcat_sim['S250'][idx_xidp][i])/fcat_sim['S250'][idx_xidp][i]
+
+#-----set up truncated boundaries for DESPHOT----
+low_clip=0.0
+up_clip=1000.0
+
+for i in range(0,nsources_xid):
+    my_mean=fcat['F250'][i]
+    my_std=fcat['E250'][i]
+    a,b = (low_clip - my_mean)/my_std,(up_clip - my_mean)/my_std
+    error_percent_xid1_250[i]=100.0*stats.norm.cdf(fcat_sim['S250'][i],loc=fcat['F250'][i],scale=fcat['E250'][i])
+    error_percent_xid2_250[i]=100.0*stats.truncnorm.cdf((fcat_sim['S250'][i]-my_mean)/my_std,a,b)
+    lq,uq=stats.truncnorm.interval(0.5,a,b)
+    IQR_xid_250[i]=((uq*my_std)-(lq*my_std))/my_mean
+    accuracy_xid_250[i]=(my_mean-fcat_sim['S250'][i])/fcat_sim['S250'][i]
+
+
+bins=np.array([0.0,0.0032,0.135,2.275,15.87,50.0,84.13,97.725,99.865,99.9968,100.0])
+ind_3mjy=fcat_sim['S250']>3
+hist_xid1,bin_eges_xid1=np.histogram(error_percent_xid1_250[ind_3mjy],bins)
+hist_xid2,bin_eges_xid2=np.histogram(error_percent_xid2_250[ind_3mjy],bins)
+
+sigma=np.arange(-4.5,5.0,1)
+fig=plt.figure()
+plt.plot(sigma,hist_xid1/float(ind_3mjy.sum()), label='DESPHOT1')
+plt.plot(sigma,hist_xid2/float(ind_3mjy.sum()), label='DESPHOT2')
+
+#plt.plot(sigma,hist_xidp/float(nsources_xidp), 'r',label='XID+')
+plt.xlabel('Flux error density (Sigma)')
+
+plt.legend()
+pdf_pages.savefig(fig)
+
+fig2=plt.figure()
+#H,xedge,yedge=np.histogram2d(np.log10(fcat_sim['S250'][idx_xidp]),error_percent_xidp_250,bins=[np.arange(-3,3,0.25),bins])
+H,xedges,yedges=np.histogram2d(np.log10(fcat_sim['S250']),error_percent_xid2_250,bins=[np.arange(0.5,2.2,0.01),bins])
+plt.imshow(H.T/np.sum(H.T,axis=0),interpolation='nearest',extent=[xedges[0],xedges[-1],sigma[0],sigma[-1]],origin='low',aspect='auto')
+plt.xlabel('S250 mJy')
+plt.ylabel('z score')
+print H.shape,xedges.shape,yedges.shape
+plt.colorbar()
+pdf_pages.savefig(fig2)
+#bins=[np.arange(-3,3,0.25),bin_eges_xidp]
+
+
+#flux precision
+fig3=plt.figure()
+H,xedges,yedges=np.histogram2d(np.log10(fcat_sim['S250']),IQR_xid_250,bins=[np.arange(0.5,2.2,0.01),np.arange(0,2,0.05)])
+plt.imshow(H.T/np.sum(H.T,axis=0),interpolation='nearest',extent=[xedges[0],xedges[-1],yedges[0],yedges[-1]],origin='low',aspect='auto')
+plt.xlabel('S250 mJy')
+plt.ylabel('IQR mJy/True')
+plt.colorbar()
+pdf_pages.savefig(fig3)
+
+fig4=plt.figure()
+H,xedges,yedges=np.histogram2d(np.log10(fcat_sim['S250']),accuracy_xid_250,bins=[np.arange(0.5,2.2,0.01),np.arange(-2,2,0.01)])
+plt.imshow(H.T/np.sum(H.T,axis=0),interpolation='nearest',extent=[xedges[0],xedges[-1],yedges[0],yedges[-1]],origin='low',aspect='auto')
+plt.xlabel('S250 mJy')
+plt.ylabel('Obs -True / True mJy')
+plt.colorbar()
+pdf_pages.savefig(fig4)
+
+pdf_pages.close()

--- a/scripts/posterior_comparisons.py
+++ b/scripts/posterior_comparisons.py
@@ -26,7 +26,7 @@ hdulist.close()
 #---Read in XID+ catalogue---
 #folder='/research/astro/fir/HELP/XID_plus_output/100micron/log_uniform_prior_test/'
 folder='/research/astro/fir/HELP/XID_plus_output/100micron/log_prior_flux/'
-hdulist=fits.open(folder+'Tiled_SPIRE_cat_flux_notlog.fits')
+hdulist=fits.open(folder+'Tiled_SPIRE_cat_flux_notlog_norm1.fits')
 fcat_xidp=hdulist[1].data
 hdulist.close()
 
@@ -41,7 +41,8 @@ idx,d2d,d3d,= c.match_to_catalog_sky(c1)
 c= SkyCoord(ra=fcat_xidp['ra']*u.degree,dec=fcat_xidp['dec']*u.degree)
 c1=SkyCoord(ra=fcat_sim['RA']*u.degree,dec=fcat_sim['DEC']*u.degree)
 idx_xidp,d2d,d3d,= c.match_to_catalog_sky(c1)
-
+idx_xidp=fcat_sim['S100'] >0.050#cut so that only sources with a 100micron flux of > 50 micro janskys (Roseboom et al. 2010 cut 24 micron sources at 50microJys)
+#idx_xidpT=fcat_sim['S100'] >0.050
 #----output folder-----------------
 output_folder='/research/astro/fir/HELP/XID_plus_output/100micron/log_prior_flux/'
 


### PR DESCRIPTION
Code changes so that stan function return `fit'. This contains all the info from the fit including chains.

This fit structure is passed into the posterior class on initiation, and calculated Rhat and neff automatically. It then saves the samples to the same variable as before.
