### PR TITLE
Update README with missing modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Requires the following python modules (all can be installed via pip)
 4. numpy
 5. scipy
 6. astropy
-
+7. mocpy
+8. healpy
 
 ##Tests
 


### PR DESCRIPTION
README missed mocpy and healpy in modules that are needed to run XID+
